### PR TITLE
Fix for N.A. websites and removing the 'Filter content by multiple tags' tag

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -367,7 +367,8 @@ class EXCAgent(Agent.Movies):
         for genreLink in genres:
           genreName = genreLink.text_content().strip('\n')
           if len(genreName) > 0 and re.match(r'View Complete List', genreName) is None:
-            metadata.genres.add(genreName)
+            if re.match(r'Filter content by multiple tags', genreName) is None:
+              metadata.genres.add(genreName)
       Log('Genre Sequence Updated')
     except: pass
 


### PR DESCRIPTION
Hello, I did a quick fix for being able to search for N.A. content. This content was problematic since it does not appear in the search. The way I found out is to go by the scene actress and the website name to get the search results.

So I made a distinct function just for that purpose and I branch at the right place to use this function when needed.

The other fix was to remove the useless 'Filter content by multiple tags' tag.
