### PR TITLE
Fix content id search

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -56,13 +56,13 @@ def search_na(results, media_title, year, lang):
     search_results = HTML.ElementFromURL(searchURL)
 
   try:
-    searchURL = find_option_value(searchURL, search_results, search)
+    searchURL = find_option_value(searchURL, search_results, na_url_site)
   except:
     try:
-      searchURL = find_option_value(searchURL, search_results, re.sub(r'[\'\"]', '', search))
+      searchURL = find_option_value(searchURL, search_results, re.sub(r'[\'\"]', '', na_url_site))
     except:
       search_results = HTML.ElementFromURL(searchURL + '/sites/')
-      xp = xpath_prepare('//a[text()[contains(translate(., "$u", "$l"), "$s")]]//@href', search)
+      xp = xpath_prepare('//a[text()[contains(translate(., "$u", "$l"), "$s")]]//@href', na_url_site)
       Log('xPath: ' + xp)
       searchURL = search_results.xpath(xp)[0]
 


### PR DESCRIPTION
@chidychi this patch includes my last message from the PM in the plex forums.

Also added a check to see if we are looking for a content id, some titles 10 positions in 2 minutes for example, get considered as NA content, and if not found, stops the search. This way, if we try a content ID and it's found it at least continues with it.

Let me know your thoughts, this is halkon from the plex forums.
